### PR TITLE
fix: make startだけでバックエンド起動できるようにしました

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,2 @@
+start:
+	docker compose --profile db --profile backend up

--- a/backend/README.md
+++ b/backend/README.md
@@ -16,10 +16,9 @@ After you installed Docker Desktop, you can launch the backend app with these co
 
 ```
 cd backend
-docker compose --profile backend --profile db up --build
-
-docker compose --profile --profile db backend up
-// ↑ After you build the docker image, you don't need to specify --build option anymore
+make start
+// or
+docker compose --profile db --profile  backend up
 ```
 
 The app is available on `http://localhost:8000`.


### PR DESCRIPTION
# 概要
`docker compose --profile db --profile backend up`と打つのは大変なので make コマンドを使用して簡単なコマンドで実行できるようにしました。

```
make start
```
だけでこれからは起動できます。

しかしバックエンドに新しいパッケージを追加するなど、再ビルドを要するものは`docker compose build`してからじゃないと動きません。