### PR TITLE
OpenID ConnectでidTokenを得る

### DIFF
--- a/backend/src/controllers/rest_api/auth_rest_controller.py
+++ b/backend/src/controllers/rest_api/auth_rest_controller.py
@@ -1,21 +1,64 @@
-from fastapi import Depends
+import os
+from fastapi import Depends, HTTPException, Query
+from fastapi.security import OAuth2AuthorizationCodeBearer
+from fastapi.responses import RedirectResponse
 from src.database import session_factory
 from src.models import RestApiController, HttpMethod, LoginRequest, User
 from typing import List
 from src.usecases.auth.login import login
 from sqlalchemy.orm import Session
+from dotenv import load_dotenv
+import httpx
+
+load_dotenv(".env.local")
+
+CLIENT_ID = os.getenv("CLIENT_ID")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+REDIRECT_URI = os.getenv("REDIRECT_URI")
+AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+oauth2_scheme = OAuth2AuthorizationCodeBearer(
+    authorizationUrl=AUTHORIZATION_URL,
+    tokenUrl=TOKEN_URL
+)
 
 
 class LoginRestApiController(RestApiController):
-    method = "PUT"
+    method = "GET"
     path = "/login"
-    response_model = User
+    response_model = None
 
-    async def controller(self, login_request: LoginRequest, session: Session = Depends(session_factory)):
-        user = login(session, login_request)
-        return user
+    async def controller(self, session: Session = Depends(session_factory)):
+        auth_url = (f"{AUTHORIZATION_URL}"
+                    f"?response_type=code&client_id={CLIENT_ID}&"
+                    f"redirect_uri={REDIRECT_URI}&"
+                    f"scope=openid%20email%20profile&"
+                    f"access_type=offline&prompt=consent")
+        return RedirectResponse(auth_url)
+
+
+class OAuthCallbackRestApiController(RestApiController):
+    method = "GET"
+    path = "/oauth2/login/callback"
+    response_model = None
+
+    async def controller(self, code: str, session: Session = Depends(session_factory)):
+        async with httpx.AsyncClient() as client:
+            token_response = await client.post(TOKEN_URL, data={
+                "code": code,
+                "client_id": CLIENT_ID,
+                "client_secret": CLIENT_SECRET,
+                "redirect_uri": REDIRECT_URI,
+                "grant_type": "authorization_code"
+            })
+        token_response_json = token_response.json()
+        if token_response.is_error:
+            raise HTTPException(status_code=400, detail=token_response_json)
+        return token_response_json
 
 
 auth_rest_api_controllers: List[RestApiController] = [
-    LoginRestApiController()
+    LoginRestApiController(),
+    OAuthCallbackRestApiController()
 ]


### PR DESCRIPTION
# 概要

Googleアカウントによるログインの実装の最初の一歩となる、IDトークンの取得を行いました。取得するところまでやっただけで、まだ何も進んでいません。

`http://localhost:8000/login`に対してブラウザからアクセスするとログインできます。

**認証処理の実装は一つのPRで完結できないため、develop/auth ブランチに対してこれからマージしていきます（いわゆるdevelop ブランチってやつ）**

@y-ma3 ローカルで動かす場合は.env.localの更新が必要となるため、また機密情報を送るのでSlackで声かけてください。

# OpenID Connect
OpenID Connectという認証のためのプロトコルに準拠しています。
↓ この記事が理解の助けになったので貼ります。
[とほほのOpenID Connect](https://www.tohoho-web.com/ex/openid-connect.html)

# 今後の実装方針の共有
- Flutter側でログイン画面を立ち上げる
- バックエンド：IDトークンを元に認証処理の実装