### PR TITLE
meエンドポイントの追加

### DIFF
--- a/backend/src/controllers/rest_api/user_rest_controller.py
+++ b/backend/src/controllers/rest_api/user_rest_controller.py
@@ -21,4 +21,14 @@ class UsersRestApiController(RestApiController):
         return users
 
 
-user_rest_api_controllers: List[RestApiController] = [UsersRestApiController()]
+class MeRestApiController(RestApiController):
+    method = "GET"
+    path = "/me"
+    response_model = User
+
+    async def controller(self, user_model=Depends(verify_user)):
+        return TypeAdapter(User).validate_python(user_model.__dict__)
+
+
+user_rest_api_controllers: List[RestApiController] = [
+    UsersRestApiController(), MeRestApiController()]

--- a/backend/src/usecases/auth/login.py
+++ b/backend/src/usecases/auth/login.py
@@ -13,7 +13,7 @@ def login(db_session: Session, id_info: IdInfo) -> UserModel:
     `is_admin` flag is set to false temporarily.(I haven't implemented the admin feature yet)
     """
     user_crud = UserCrud(UserModel)
-    user = user_crud.get_by_emmail(db_session, id_info["email"])
+    user = user_crud.get_by_email(db_session, id_info["email"])
     if user:
         user_update = UserUpdate(
             name=id_info['name'],


### PR DESCRIPTION
# 概要
meエンドポイントを追加しました。AuthorazationヘッダにIDトークンを格納してアクセスした時にそのユーザーのUserオブジェクトを返します。

関連ドキュメント　[クライアント側：認証](https://school-interview.atlassian.net/wiki/spaces/a8558504ee1440048aefa419afc80e13/pages/8388626)

# 検討事項
## 候補１：今の実装ではこのAPIを呼び出した時にUserオブジェクトが帰ってきます。しかしこれを将来的に変更しようと思ってます。

これまではUserクラスで学科とか学年とかの情報を持っていましたが、今はUserとStudentクラスに分離されています。
```
class User(BaseModel):
    id: UUID
    name: str
    email: str
    is_admin: bool
```
```
class Student(BaseModel):
    id: UUID
    user_id: UUID
    user: Optional[User]
    student_id: str
    department: str
    semester: int = Field(ge=1, le=8)

```

しかしどちらの情報もクライアント側は必要だと思います。

なのでこの二つを組み合わせたような新たなクラスを検討しています。
(これをmeエンドポイントにアクセスした時に返そうと思っている)

イメージとしてはこんな感じ
```
class StudentUser(BaseModel):
    id: UUID
    name: str
    email: str
    is_admin: bool
    student_id: str
    department: str
    semester: int = Field(ge=1, le=8)
```
## 候補２：`/me`を呼び出した後`/students/{student_id}`みたいなAPIを呼び出す方式
要はUserとStudentの二つのデータ型がクライアントに渡ればいいので、
`User.is_admin`を読んで、falseだったら`/students/{student_id}`みたいなAPIにアクセスしてStudentオブジェクトを得ればいいのです。


