### PR TITLE
fix: docker composeのextendsがprofilesも継承してしまうことによりdebugをextends使わないように…

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -24,12 +24,27 @@ services:
     profiles:
       - backend
   debug:
-    extends:
-      service: backend-app
-    environment:
-      - DEBUG=True
+    build: .
+    volumes:
+      - ./src:/app/src
+      - ./test:/app/test
+      - ./launch-server-docker.sh:/app/launch-server-docker.sh
+      - ./alembic.ini:/app/alembic.ini
+      - ./migrations:/app/migrations
+      - ./.env:/app/.env
+      - ./.env.local:/app/.env.local
+      - ./pdf:/app/pdf
     ports:
+      - 8000:8000
       - 5678:5678
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      PYTHONPATH: "$PYTHONPATH:/app/src"
+      DATABASE_URL: "postgresql://user:postgres@db:5432/school-interview"
+      DEBUG: "True"
+    depends_on:
+      - db
     profiles:
       - debug
   db:


### PR DESCRIPTION
…しました

debug用コンテナのprofilesに`backend`と`debug`が指定されているという問題でした。

つまり`backend`プロファイルのコンテナを起動しようとすると、二つのバックエンドアプリが起動しようとしますが8000番ポートを使えるのは一つだけなのでalready in useなエラーが出てしまっている状況でした