### PR TITLE
バックエンドのテスト用のGithub Actionをbackendディレクトリ以下が変更合った時のみ実行されるようにしました

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,6 +2,7 @@ name: UnitTest
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
+    paths: ["backend/**"]
 
 jobs:
   unit-test:
@@ -23,14 +24,6 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('backend/pyproject.toml') }}
           restore-keys: |
             venv-${{ runner.os }}-
-      # - name: restore poetry cache
-      #   id: cache-poetry
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: /home/runner/.local/bin/poetry
-      #     key: poetry-${{ runner.os }}-${{ hashFiles('backend/pyproject.toml') }}
-      #     restore-keys: |
-      #       poetry-${{ runner.os }}-
       - name: install poetry
         # if: steps.cache-poetry.outputs.cache-hit == 'false'
         uses: snok/install-poetry@v1


### PR DESCRIPTION
バックエンドのテスト用のGithub Actionをbackendディレクトリ以下が変更合った時のみ実行されるようにしました。

また、使っていない箇所のコメントを消しました。

（cacheをrestoreするつもりで使っていたと思うんですが、たぶんactions/cache@v3を一回でも使ってればその心配はないはずなので消します）