### PR TITLE
ISSUEにラベルをつける作業を自動化する

### DIFF
--- a/.github/ISSUE_TEMPLATE/normal_template.yaml
+++ b/.github/ISSUE_TEMPLATE/normal_template.yaml
@@ -1,0 +1,35 @@
+name: タスク
+description: タスクを作成する
+body:
+  - type: dropdown
+    id: related
+    attributes:
+      label: 関連するもの
+      description: このタスクが関連するものを選択してください。
+      multiple: false
+      options:
+        - "Backend"
+        - "Client"
+        - "Other"
+        - "All"
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: タスクの種類
+      description: このタスクの種類を選択してください。
+      multiple: false
+      options:
+        - "Feature"
+        - "Bug"
+        - "Improvement"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: このタスクの目的や背景について簡潔に記述してください。
+    validations:
+      required: false

--- a/.github/labeler-issue.yaml
+++ b/.github/labeler-issue.yaml
@@ -1,0 +1,21 @@
+policy:
+  - template: [ "normal_template.yaml" ]
+    section:
+      - id: [ "related" ]
+        block-list: [ ]
+        label:
+          - name: "related/backend"
+            keys: [ "Backend", "All" ]
+          - name: "related/client"
+            keys: [ "Client", "All" ]
+          - name: "related/other"
+            keys: [ "Other", "All" ]
+      - id: [ type ]
+        block-list: [ ]
+        label:
+          - name: "type/feature"
+            keys: [ "Feature" ]
+          - name: "type/bug"
+            keys: [ "Bug" ]
+          - name: "related/improvement"
+            keys: [ "Improvement" ]

--- a/.github/workflows/labeler-issue.yaml
+++ b/.github/workflows/labeler-issue.yaml
@@ -1,0 +1,40 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  labeler-issue:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    strategy:
+      matrix:
+        template:
+          - normal_template.yaml
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # https://github.com/stefanbuck/github-issue-parser
+      - name: Parse issue form
+        uses: stefanbuck/github-issue-parser@2d2ff50d4aae06ab58d26bf59468d98086605f11 # v3.2.1
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
+
+      # https://github.com/redhat-plumbers-in-action/advanced-issue-labeler
+      - name: Set labels based on severity field
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@d498805e5c7c0658e336948b3363480bcfd68da6 # v3.2.0
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          template: ${{ matrix.template }}
+          config-path: .github/labeler-issue.yaml
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Issue

- Closes #207 

## 変更内容
* issue作成時に自動でラベルがつくようになりました。
* issueを`タスク`テンプレートを使用して作成したときのみラベルがつきます。

こちらはレビューなしでマージします。
