### PR TITLE
.create()が誤字っていました

### DIFF
--- a/backend/src/usecases/auth/login.py
+++ b/backend/src/usecases/auth/login.py
@@ -39,7 +39,7 @@ def login(db_session: Session, id_info: IdInfo) -> UserModel:
                 id=uuid.uuid4(),
                 user_id=user_model.id
             )
-            admins_crud.crate(db_session, obj_in=admin_model)
+            admins_crud.create(db_session, obj_in=admin_model)
         else:
             students_crud = StudentsCrud(StudentModel)
             studnet_model = StudentModel(


### PR DESCRIPTION
## 変更内容

管理者のメールアドレスでの初回ログイン時、管理者情報をDBに登録するためのメソッド名にtypoがありました。。

