### PR TITLE
extraction後にboolはjson()で変換されるため，自前の変換ロジックは必要なかった

### DIFF
--- a/backend/src/usecases/interview/speak_to_teacher.py
+++ b/backend/src/usecases/interview/speak_to_teacher.py
@@ -132,8 +132,6 @@ def extract_value(
     extracted_value = response.json()['extracted_value']
 
     match current_question.extraction_data_type:
-        case 'bool':
-            extracted_value = True if extracted_value.lower() == 'true' else False
         case 'int':
             if extracted_value is not None:
                 extracted_value = int(extracted_value)


### PR DESCRIPTION
# 概要
bool値の抽出後，APIサーバーで以下のエラーが発生していた．

bool文字列をbool型に変換するロジックがあったが，json()による変換で既にbool型に変換されていたため，該当箇所を削除．
```
backend-1                  |   File "/app/src/usecases/interview/speak_to_teacher.py", line 136, in extract_value
backend-1                  |     extracted_value = True if extracted_value.lower() == 'true' else False
backend-1                  |                               ^^^^^^^^^^^^^^^^^^^^^
backend-1                  | AttributeError: 'bool' object has no attribute 'lower'
```

